### PR TITLE
Refactor/migration options to manifest v3

### DIFF
--- a/dist.files
+++ b/dist.files
@@ -3,3 +3,4 @@ browser-polyfill.js
 ff2mpv.js
 LICENSE
 icons/
+options/

--- a/ff2mpv
+++ b/ff2mpv
@@ -6,8 +6,10 @@ require "json"
 len = $stdin.read(4).unpack1("L")
 data = JSON.parse($stdin.read(len))
 url = data["url"]
+options = data["options"] || []
 
 args = %w[--no-terminal]
+args.push(*options)
 
 # HACK(ww): On macOS, graphical applications inherit their path from `launchd`
 # rather than the default path list in `/etc/paths`. `launchd` doesn't include

--- a/ff2mpv
+++ b/ff2mpv
@@ -18,7 +18,7 @@ args.push(*options)
 # from, say, Firefox. The real fix is to modify `launchd.conf`, but that's
 # invasive and maybe not what users want in the general case.
 # Hence this nasty hack.
-ENV["PATH"] = "/usr/local/bin:#{ENV['PATH']}" if RUBY_PLATFORM =~ /darwin/
+ENV["PATH"] = "/usr/local/bin:/opt/homebrew/bin:#{ENV['PATH']}" if RUBY_PLATFORM =~ /darwin/
 
 pid = spawn "mpv", *args, "--", url, in: :close, out: "/dev/null", err: "/dev/null"
 

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -5,6 +5,7 @@ function onError(error) {
 }
 
 const OPEN_VIDEO = 'openVideo';
+let TITLE;
 
 function ff2mpv(url, options = []) {
   browser.tabs.executeScript({
@@ -32,21 +33,58 @@ async function getOptions(id) {
 }
 
 async function submenuClicked(info) {
-  switch (info.parentMenuItemId) {
-    case "ff2mpv":
-      /* These should be mutually exclusive, but,
-         if they aren't, this is a reasonable priority.
-      */
-      url = info.linkUrl || info.srcUrl || info.selectionText || info.frameUrl;
-      if (url) {
-        const options = await getOptions(info.menuItemId);
-        ff2mpv(url, options);
-      }
-    break;
+  if (info.parentMenuItemId === 'ff2mpv' || info.menuItemId === 'ff2mpv') {
+    /* These should be mutually exclusive, but,
+       if they aren't, this is a reasonable priority.
+    */
+    const url = info.linkUrl || info.srcUrl || info.selectionText || info.frameUrl;
+    if (url) {
+      const options = await getOptions(info.menuItemId);
+      ff2mpv(url, options);
+    }
   }
 }
 
-function createProfile(profile) {
+function changeToMultiEntries() {
+  // Remove single entry
+  browser.contextMenus.remove('ff2mpv');
+
+  // Add sub context menu
+  browser.contextMenus.create({
+    id: "ff2mpv",
+    title: "Profiles",
+    contexts,
+    onclick: submenuClicked,
+  });
+
+  browser.contextMenus.create({
+    parentId: "ff2mpv",
+    title: TITLE,
+    contexts,
+    onclick: submenuClicked,
+  });
+}
+
+function changeToSingleEntry() {
+  // Remove sub context menu
+  browser.contextMenus.remove('ff2mpv');
+
+  // Add single entry
+  browser.contextMenus.create({
+    id: "ff2mpv",
+    title: TITLE,
+    contexts,
+    onclick: submenuClicked,
+  });
+}
+
+async function createProfile(profile) {
+  const profiles = await getProfiles();
+
+  if (profiles.length === 0) {
+    changeToMultiEntries();
+  }
+
   browser.contextMenus.create({
     parentId: "ff2mpv",
     id: profile.id,
@@ -56,8 +94,15 @@ function createProfile(profile) {
   })
 }
 
-function deleteProfile(menuItemId) {
+async function deleteProfile(menuItemId) {
   browser.contextMenus.remove(menuItemId);
+
+  const profiles = (await getProfiles())
+    .filter(pf => pf.id !== menuItemId);
+
+  if (profiles.length === 0) {
+    changeToSingleEntry();
+  }
 }
 
 function updateProfile(profile) {
@@ -66,57 +111,49 @@ function updateProfile(profile) {
   });
 }
 
+browser.browserAction.onClicked.addListener((tab) => {
+  ff2mpv(tab.url);
+});
+
+// Messages sent with browser.runtime.sendMessage (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage) from external applications will be handle here.
+// ref: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal
+browser.runtime.onMessageExternal.addListener((request, sender, sendResponse) => {
+  if (!request) {
+    console.warn('No request in external message');
+    return;
+  }
+
+  const { type, url } = request;
+  console.debug('Request from:', sender);
+
+  switch (type) {
+    case OPEN_VIDEO:
+      ff2mpv(url);
+      return sendResponse('ok');
+    default:
+      console.warn('No handler for external type:', type);
+      return;
+  }
+});
+
 getOS().then(async (os) => {
-  var title = os == "win" ? "Play in MP&V" : "Play in MPV (&W)";
-
-  browser.contextMenus.create({
-    id: "ff2mpv",
-    title: "Profiles",
-    contexts,
-  });
-
-  // Default entry
-  browser.contextMenus.create({
-    parentId: "ff2mpv",
-    title,
-    contexts,
-    onclick: submenuClicked,
-  });
+  TITLE = os === "win" ? "Play in MP&V" : "Play in MPV (&W)";
 
   const profiles = await getProfiles();
 
-  profiles.forEach(profile => {
-    browser.contextMenus.create({
-      parentId: "ff2mpv",
-      id: profile.id,
-      title: profile.name,
-      contexts,
-      onclick: submenuClicked,
-    })
-  });
+  if (profiles.length === 0) {
+    changeToSingleEntry();
+  } else {
+    changeToMultiEntries();
 
-  browser.browserAction.onClicked.addListener((tab) => {
-    ff2mpv(tab.url);
-  });
-
-  // Messages sent with browser.runtime.sendMessage (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage) from external applications will be handle here.
-  // ref: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal
-  browser.runtime.onMessageExternal.addListener((request, sender, sendResponse) => {
-    if (!request) {
-      console.warn('No request in external message');
-      return;
-    }
-
-    const { type, url } = request;
-    console.debug('Request from:', sender);
-
-    switch (type) {
-      case OPEN_VIDEO:
-        ff2mpv(url);
-        return sendResponse('ok');
-      default:
-        console.warn('No handler for external type:', type);
-        return;
-    }
-  });
+    profiles.forEach(profile => {
+      browser.contextMenus.create({
+        parentId: "ff2mpv",
+        id: profile.id,
+        title: profile.name,
+        contexts,
+        onclick: submenuClicked,
+      })
+    });
+  }
 });

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -1,40 +1,99 @@
+const contexts = ["link", "image", "video", "audio", "selection", "frame"];
+
 function onError(error) {
-    console.log(`${error}`);
+  console.log(`${error}`);
 }
 
-function ff2mpv(url) {
-    browser.tabs.executeScript({
-        code: "video = document.getElementsByTagName('video');video[0].pause();"
-    });
-    browser.runtime.sendNativeMessage("ff2mpv", { url: url }).catch(onError);
+function ff2mpv(url, options = []) {
+  browser.tabs.executeScript({
+    code: "video = document.getElementsByTagName('video');video[0].pause();"
+  });
+  browser.runtime.sendNativeMessage("ff2mpv", { url, options }).catch(onError);
 }
 
 async function getOS() {
   return browser.runtime.getPlatformInfo().then((i) => i.os);
 }
 
-getOS().then((os) => {
+async function getProfiles() {
+  return (await browser.storage.sync.get('profiles'))['profiles'] || [];
+};
+
+async function getOptions(id) {
+  const profiles = await getProfiles();
+  const profile = profiles.find(pf => pf.id === id);
+
+  // If profile, remove empty lines
+  return profile
+    ? profile.content.filter(line => !!line)
+    : [];
+}
+
+async function submenuClicked(info) {
+  switch (info.parentMenuItemId) {
+    case "ff2mpv":
+      /* These should be mutually exclusive, but,
+         if they aren't, this is a reasonable priority.
+      */
+      url = info.linkUrl || info.srcUrl || info.selectionText || info.frameUrl;
+      if (url) {
+        const options = await getOptions(info.menuItemId);
+        ff2mpv(url, options);
+      }
+    break;
+  }
+}
+
+function createProfile(profile) {
+  browser.contextMenus.create({
+    parentId: "ff2mpv",
+    id: profile.id,
+    title: profile.name,
+    contexts,
+    onclick: submenuClicked,
+  })
+}
+
+function deleteProfile(menuItemId) {
+  browser.contextMenus.remove(menuItemId);
+}
+
+function updateProfile(profile) {
+  browser.contextMenus.update(profile.id, {
+    title: profile.name,
+  });
+}
+
+getOS().then(async (os) => {
   var title = os == "win" ? "Play in MP&V" : "Play in MPV (&W)";
 
   browser.contextMenus.create({
-      id: "ff2mpv",
-      title: title,
-      contexts: ["link", "image", "video", "audio", "selection", "frame"]
+    id: "ff2mpv",
+    title: "Profiles",
+    contexts,
   });
 
-  browser.contextMenus.onClicked.addListener((info, tab) => {
-      switch (info.menuItemId) {
-          case "ff2mpv":
-              /* These should be mutually exclusive, but,
-                 if they aren't, this is a reasonable priority.
-              */
-              url = info.linkUrl || info.srcUrl || info.selectionText || info.frameUrl;
-              if (url) ff2mpv(url);
-              break;
-      }
+  // Default entry
+  browser.contextMenus.create({
+    parentId: "ff2mpv",
+    title,
+    contexts,
+    onclick: submenuClicked,
+  });
+
+  const profiles = await getProfiles();
+
+  profiles.forEach(profile => {
+    browser.contextMenus.create({
+      parentId: "ff2mpv",
+      id: profile.id,
+      title: profile.name,
+      contexts,
+      onclick: submenuClicked,
+    })
   });
 
   browser.browserAction.onClicked.addListener((tab) => {
-      ff2mpv(tab.url);
+    ff2mpv(tab.url);
   });
 });

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -4,6 +4,8 @@ function onError(error) {
   console.log(`${error}`);
 }
 
+const OPEN_VIDEO = 'openVideo';
+
 function ff2mpv(url, options = []) {
   browser.tabs.executeScript({
     code: "video = document.getElementsByTagName('video');video[0].pause();"
@@ -95,5 +97,26 @@ getOS().then(async (os) => {
 
   browser.browserAction.onClicked.addListener((tab) => {
     ff2mpv(tab.url);
+  });
+
+  // Messages sent with browser.runtime.sendMessage (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage) from external applications will be handle here.
+  // ref: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal
+  browser.runtime.onMessageExternal.addListener((request, sender, sendResponse) => {
+    if (!request) {
+      console.warn('No request in external message');
+      return;
+    }
+
+    const { type, url } = request;
+    console.debug('Request from:', sender);
+
+    switch (type) {
+      case OPEN_VIDEO:
+        ff2mpv(url);
+        return sendResponse('ok');
+      default:
+        console.warn('No handler for external type:', type);
+        return;
+    }
   });
 });

--- a/ff2mpv.js
+++ b/ff2mpv.js
@@ -19,17 +19,27 @@ async function getOS() {
 }
 
 async function getProfiles() {
-  return (await browser.storage.sync.get('profiles'))['profiles'] || [];
+  try {
+    return (await browser.storage.sync.get('profiles'))['profiles'] || [];
+  } catch (error) {
+    console.debug('Unable to get profiles:', error);
+    return [];
+  }
 };
 
 async function getOptions(id) {
-  const profiles = await getProfiles();
-  const profile = profiles.find(pf => pf.id === id);
+  try {
+    const profiles = await getProfiles();
+    const profile = profiles.find(pf => pf.id === id);
 
-  // If profile, remove empty lines
-  return profile
-    ? profile.content.filter(line => !!line)
-    : [];
+    // If profile, remove empty lines
+    return profile
+      ? profile.content.filter(line => !!line)
+      : [];
+  } catch (error) {
+    console.debug('Unable to get options for profile:', id, error);
+    return [];
+  }
 }
 
 async function submenuClicked(info) {
@@ -47,7 +57,9 @@ async function submenuClicked(info) {
 
 function changeToMultiEntries() {
   // Remove single entry
-  browser.contextMenus.remove('ff2mpv');
+  try {
+    browser.contextMenus.remove('ff2mpv');
+  } catch (error) {}
 
   // Add sub context menu
   browser.contextMenus.create({
@@ -67,7 +79,9 @@ function changeToMultiEntries() {
 
 function changeToSingleEntry() {
   // Remove sub context menu
-  browser.contextMenus.remove('ff2mpv');
+  try {
+    browser.contextMenus.remove('ff2mpv');
+  } catch (error) {}
 
   // Add single entry
   browser.contextMenus.create({

--- a/ff2mpv.py
+++ b/ff2mpv.py
@@ -29,7 +29,7 @@ def main():
     # Hence this nasty hack.
     if platform.system() == "Darwin":
         path = os.environ.get("PATH")
-        os.environ["PATH"] = f"/usr/local/bin:{path}"
+        os.environ["PATH"] = f"/usr/local/bin:/opt/homebrew/bin:{path}"
 
     subprocess.Popen(args, **kwargs)
 

--- a/ff2mpv.py
+++ b/ff2mpv.py
@@ -11,8 +11,9 @@ import subprocess
 def main():
     message = get_message()
     url = message.get("url")
+    options = message.get("options") or []
 
-    args = ["mpv", "--no-terminal", "--", url]
+    args = ["mpv", "--no-terminal", *options, "--", url]
 
     kwargs = {}
     # https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging#Closing_the_native_app

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,11 @@
     "name": "ff2mpv",
     "version": "4.0.0",
 
+    "options_ui": {
+        "page": "options/options.html",
+        "open_in_tab": false
+    },
+
     "icons": {
         "16": "icons/icon_16x16.png",
         "32": "icons/icon_32x32.png",
@@ -40,5 +45,5 @@
         ]
     },
 
-    "permissions": ["nativeMessaging", "contextMenus", "activeTab"]
+    "permissions": ["nativeMessaging", "contextMenus", "activeTab", "storage"]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "description": "Tries to play links in MPV",
     "manifest_version": 2,
     "name": "ff2mpv",
-    "version": "5.0.1",
+    "version": "5.1.0",
     "options_ui": {
         "page": "options/options.html",
         "open_in_tab": false

--- a/manifest.json
+++ b/manifest.json
@@ -2,13 +2,11 @@
     "description": "Tries to play links in MPV",
     "manifest_version": 2,
     "name": "ff2mpv",
-    "version": "4.0.0",
-
+    "version": "5.0.0",
     "options_ui": {
         "page": "options/options.html",
         "open_in_tab": false
     },
-
     "icons": {
         "16": "icons/icon_16x16.png",
         "32": "icons/icon_32x32.png",
@@ -16,12 +14,10 @@
         "64": "icons/icon_64x64.png",
         "256": "icons/icon_256x256.png"
     },
-
     "browser_action": {
         "default_icon": "icons/icon_48x48.png",
         "default_title": "Play the current URL in MPV"
     },
-
     "commands": {
         "_execute_browser_action": {
             "suggested_key": {
@@ -30,20 +26,22 @@
             "description": "Play the current URL in mpv"
         }
     },
-
     "applications": {
         "gecko": {
             "id": "ff2mpv@yossarian.net",
             "strict_min_version": "50.0"
         }
     },
-
     "background": {
         "scripts": [
             "browser-polyfill.js",
             "ff2mpv.js"
         ]
     },
-
-    "permissions": ["nativeMessaging", "contextMenus", "activeTab", "storage"]
+    "permissions": [
+        "nativeMessaging",
+        "contextMenus",
+        "activeTab",
+        "storage"
+    ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "description": "Tries to play links in MPV",
     "manifest_version": 2,
     "name": "ff2mpv",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "options_ui": {
         "page": "options/options.html",
         "open_in_tab": false

--- a/manifest.json
+++ b/manifest.json
@@ -32,10 +32,15 @@
         "persistent": false,
         "service_worker": "ff2mpv.js"
     },
+    "options_ui": {
+        "page": "options/options.html",
+        "open_in_tab": false
+    },
     "permissions": [
         "nativeMessaging",
         "contextMenus",
         "activeTab",
+        "storage",
         "scripting"
     ]
 }

--- a/options/options.css
+++ b/options/options.css
@@ -1,0 +1,173 @@
+:root {
+  --light-theme-profile-odd: hsl(0, 0%, 95%);
+  --light-theme-profile-border: hsl(0, 0%, 0%);
+  --light-theme-color: hsl(0, 0%, 0%);
+  --light-theme-background: hsl(0, 0%, 100%);
+  --light-theme-background-input: hsl(0, 0%, 100%);
+  --light-theme-normal-button: hsl(300, 67%, 42%);
+  --light-theme-delete-button: hsl(0, 100%, 50%);
+  --light-theme-button-color: hsl(0, 0%, 100%);
+  --light-theme-normal-button-hover: hsl(300, 67%, 22%);
+  --light-theme-delete-button-hover: hsl(0, 100%, 30%);
+  --light-theme-warning-background: hsl(62, 90%, 85%);
+  --light-theme-warning-text: hsl(49, 26%, 20%);
+  --light-theme-warning-url: hsl(240, 100%, 40%);
+  --light-theme-warning-url-visited: hsl(271, 68%, 32%);
+
+  --dark-theme-profile-odd: hsl(255, 6%, 8%);
+  --dark-theme-profile-border: hsl(0, 0%, 56%);
+  --dark-theme-color: hsl(0, 0%, 89%);
+  --dark-theme-background: hsl(255, 6%, 13%);
+  --dark-theme-background-input: hsl(255, 6%, 28%);
+  --dark-theme-normal-button: hsl(300, 67%, 22%);
+  --dark-theme-delete-button: hsl(0, 100%, 30%);
+  --dark-theme-button-color: hsl(0, 0%, 89%);
+  --dark-theme-normal-button-hover: hsl(300, 67%, 42%);
+  --dark-theme-delete-button-hover: hsl(0, 100%, 50%);
+  --dark-theme-warning-background: hsl(49, 26%, 20%);
+  --dark-theme-warning-text: hsl(45, 97%, 70%);
+  --dark-theme-warning-url: hsl(93, 65%, 50%);
+  --dark-theme-warning-url-visited: hsl(93, 45%, 30%);
+
+  /* Use light theme as default */
+  --profile-odd: var(--light-theme-profile-odd);
+  --profile-border: var(--light-theme-profile-border);
+  --color: var(--light-theme-color);
+  --background: var(--light-theme-background);
+  --backgraund-input: var(--light-theme-background-input);
+  --normal-button: var(--light-theme-normal-button);
+  --delete-button: var(--light-theme-delete-button);
+  --button-color: var(--light-theme-button-color);
+  --normal-button-hover: var(--light-theme-normal-button-hover);
+  --delete-button-hover: var(--light-theme-delete-button-hover);
+  --warning-background: var(--light-theme-warning-background);
+  --warning-text: var(--light-theme-warning-text);
+  --warning-url: var(--light-theme-warning-url);
+  --warning-url-visited: var(--light-theme-warning-url-visited);
+}
+
+body {
+  min-width: 600px;
+  min-height: 300px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: var(--color);
+  background-color: var(--background);
+  box-sizing: border-box;
+}
+
+.warning {
+  display: flex;
+  font-size: 16px;
+  padding: 20px;
+  border: 2px solid var(--warning-text);
+  border-radius: 10px;
+  margin: 20px 0;
+  color: var(--warning-text);
+  background-color: var(--warning-background);
+}
+
+.warning a {
+  color: var(--warning-url);
+}
+
+.warning a:visited {
+  color: var(--warning-url-visited);
+}
+
+#profiles-wrapper {
+  width: 100%;
+}
+
+.profile:nth-child(2n + 1) {
+  background-color: var(--profile-odd);
+}
+
+.profile {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-sizing: border-box;
+  border: 2px solid var(--profile-border);
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.profile textarea, .profile input {
+  color: var(--color);
+  background-color: var(--background-input);
+}
+
+.profile textarea:focus-visible, .profile input:focus-visible {
+  outline: dotted;
+  outline-color: var(--profile-border);
+}
+
+.profile textarea {
+  height: 120px;
+}
+
+.profile + .profile {
+  margin-top: 10px;
+}
+
+.new-profile {
+  border-color: var(--normal-button);
+}
+
+.button {
+  border-radius: 5px;
+  color: var(--button-color);
+  background-color: var(--normal-button);
+}
+
+.button:focus-visible {
+  outline: dotted;
+  outline-color: var(--profile-border);
+}
+
+.button:hover {
+  background-color: var(--normal-button-hover);
+}
+
+.delete-button {
+  background-color: var(--delete-button);
+}
+
+.delete-button:hover {
+  background-color: var(--delete-button-hover);
+}
+
+.buttons-wrapper {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+#add {
+  margin-top: 20px;
+  width: 80%;
+  height: 2rem;
+  text-align: center;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* If browser settings use dark theme, override styles */
+    --profile-odd: var(--dark-theme-profile-odd);
+    --profile-border: var(--dark-theme-profile-border);
+    --color: var(--dark-theme-color);
+    --background: var(--dark-theme-background);
+    --backgraund-input: var(--dark-theme-background-input);
+    --normal-button: var(--dark-theme-normal-button);
+    --delete-button: var(--dark-theme-delete-button);
+    --button-color: var(--dark-theme-button-color);
+    --normal-button-hover: var(--dark-theme-normal-button-hover);
+    --delete-button-hover: var(--dark-theme-delete-button-hover);
+    --warning-background: var(--dark-theme-warning-background);
+    --warning-text: var(--dark-theme-warning-text);
+    --warning-url: var(--dark-theme-warning-url);
+    --warning-url-visited: var(--dark-theme-warning-url-visited);
+  }
+}

--- a/options/options.html
+++ b/options/options.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>ff2mpv options</title>
+    <link rel="stylesheet" href="options.css">
+  </head>
+  <body>
+    <div class="warning">
+      <p>
+        <strong>Warning</strong>:&nbsp;Only add profiles that you trust! Arbitrary MPV flags should be considered arbitrary code, and should be reviewed carefully. <a href="https://mpv.io/manual">See Manual.</a>
+      </p>
+    </div>
+    <div id="profiles-wrapper">
+    </div>
+    <div id="status"></div>
+    <button id="add" class="button">Add</button>
+
+    <script src="../browser-polyfill.js"></script>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/options/options.js
+++ b/options/options.js
@@ -1,0 +1,142 @@
+(() => {
+  const profilesWrapper = document.getElementById('profiles-wrapper');
+  const addButton = document.getElementById('add');
+  const PROFILES = 'profiles';
+
+  const getProfiles = async () => {
+    return (await browser.storage.sync.get(PROFILES))[PROFILES] || [];
+  };
+
+  const saveProfile = async (profile) => {
+    const storedProfiles = await getProfiles();
+    const existingProfile = storedProfiles.find(sp => sp.id === profile.id);
+    let updatedProfiles;
+
+    if (existingProfile) {
+      existingProfile.content = profile.content;
+      existingProfile.name = profile.name;
+
+      updatedProfiles = {
+        [PROFILES]: storedProfiles,
+      };
+    } else {
+      updatedProfiles = {
+        [PROFILES]: [
+          ...storedProfiles,
+          profile,
+        ]
+      };
+    }
+
+    return browser.storage.sync.set(updatedProfiles);
+  };
+
+  const deleteProfile = async (id) => {
+    const storedProfiles = await getProfiles();
+    const updatedProfiles = storedProfiles.filter(sp => sp.id !== id);
+
+    return browser.storage.sync.set({ [PROFILES]: updatedProfiles });
+  };
+
+  const onSaveProfile = (event) => {
+    const targetProfile = event.target.parentElement.parentElement;
+    const name = targetProfile.children[0].value;
+    const content = targetProfile.children[1].value
+      .trim().split('\n')
+      .map(line => line.trim());
+
+    // We need at least a name to save the profile
+    // or it won't have text on the menu context
+    if (!name) {
+      return;
+    }
+
+    const backgroundPage = browser.extension.getBackgroundPage();
+
+    // Save profile if it doesn't have an id
+    if (!targetProfile.dataset.id) {
+      targetProfile.dataset.id = crypto.randomUUID();
+      targetProfile.classList.remove('new-profile');
+
+      const id = targetProfile.dataset.id;
+      const profile = { id, name, content };
+      backgroundPage.createProfile(profile);
+
+      return saveProfile(profile);
+    }
+
+    const id = targetProfile.dataset.id;
+    const profile = { id, name, content };
+    backgroundPage.updateProfile(profile);
+
+    return saveProfile(profile);
+  };
+
+  const onDeleteProfile = (event) => {
+    const targetProfile = event.target.parentElement.parentElement;
+    const buttonsWrapper = targetProfile.children[2];
+    const id = targetProfile.dataset.id;
+
+    buttonsWrapper.children[0].removeEventListener('click', onSaveProfile);
+    buttonsWrapper.children[1].removeEventListener('click', onDeleteProfile);
+    profilesWrapper.removeChild(targetProfile);
+
+    if (id) {
+      const backgroundPage = browser.extension.getBackgroundPage();
+
+      backgroundPage.deleteProfile(id);
+
+      return deleteProfile(id);
+    }
+  };
+
+  const createProfile = ({ name = '', content = [], id }) => {
+    const profileDiv = document.createElement('div');
+    const profileName = document.createElement('input');
+    const profileContent = document.createElement('textArea');
+    const buttonsWrapper = document.createElement('div');
+    const saveButton = document.createElement('button');
+    const deleteButton = document.createElement('button');
+
+    if (id) {
+      profileDiv.dataset.id = id;
+    }
+
+    profileDiv.classList.add('profile');
+    buttonsWrapper.classList.add('buttons-wrapper');
+    saveButton.classList.add('button');
+    deleteButton.classList.add('button', 'delete-button');
+
+    profileName.placeholder = 'Profile Name';
+    profileContent.placeholder = 'mpv args (1 per line)';
+
+    saveButton.addEventListener('click', onSaveProfile);
+    deleteButton.addEventListener('click', onDeleteProfile);
+
+    profileContent.value = content.length ? content.join('\n') + '\n' : '';
+    profileName.value = name;
+
+    saveButton.textContent = 'save';
+    deleteButton.textContent = 'delete';
+
+    buttonsWrapper.append(saveButton, deleteButton);
+    profileDiv.append(profileName, profileContent, buttonsWrapper);
+
+    return profileDiv;
+  }
+
+  const load = async () => {
+    addButton.addEventListener('click', () => {
+      const emptyProfile = createProfile({});
+
+      emptyProfile.classList.add('new-profile');
+      profilesWrapper.appendChild(emptyProfile);
+    });
+
+    const profiles = await getProfiles();
+    const profileElements = profiles.map(pf => createProfile(pf));
+    profilesWrapper.replaceChildren(...profileElements);
+  };
+
+  window.addEventListener('load', load);
+})();

--- a/options/options.js
+++ b/options/options.js
@@ -1,0 +1,150 @@
+(() => {
+  const profilesWrapper = document.getElementById('profiles-wrapper');
+  const addButton = document.getElementById('add');
+  const PROFILES = 'profiles';
+  const CREATE_PROFILE = 'createProfile';
+  const UPDATE_PROFILE = 'updateProfile';
+  const DELETE_PROFILE = 'deleteProfile';
+
+  const sendMessage = (message) => {
+    chrome.runtime.sendMessage(message, (response) => {
+      // Chrome check for errors.
+      if (chrome.runtime.lastError) {
+        console.error(`There was an error with the message of type: ${message.type}`, chrome.runtime.lastError);
+      }
+    })
+  };
+
+  const getProfiles = async () => {
+    return (await chrome.storage.sync.get(PROFILES))[PROFILES] || [];
+  };
+
+  const saveProfile = async (profile) => {
+    const storedProfiles = await getProfiles();
+    const existingProfile = storedProfiles.find(sp => sp.id === profile.id);
+    let updatedProfiles;
+
+    if (existingProfile) {
+      existingProfile.content = profile.content;
+      existingProfile.name = profile.name;
+
+      updatedProfiles = {
+        [PROFILES]: storedProfiles,
+      };
+    } else {
+      updatedProfiles = {
+        [PROFILES]: [
+          ...storedProfiles,
+          profile,
+        ]
+      };
+    }
+
+    return chrome.storage.sync.set(updatedProfiles);
+  };
+
+  const deleteProfile = async (id) => {
+    const storedProfiles = await getProfiles();
+    const updatedProfiles = storedProfiles.filter(sp => sp.id !== id);
+
+    return chrome.storage.sync.set({ [PROFILES]: updatedProfiles });
+  };
+
+  const onSaveProfile = (event) => {
+    const targetProfile = event.target.parentElement.parentElement;
+    const name = targetProfile.children[0].value;
+    const content = targetProfile.children[1].value
+      .trim().split('\n')
+      .map(line => line.trim());
+
+    // We need at least a name to save the profile
+    // or it won't have text on the menu context
+    if (!name) {
+      return;
+    }
+
+    // Save profile if it doesn't have an id
+    if (!targetProfile.dataset.id) {
+      targetProfile.dataset.id = crypto.randomUUID();
+      targetProfile.classList.remove('new-profile');
+
+      const id = targetProfile.dataset.id;
+      const profile = { id, name, content };
+      sendMessage({ type: CREATE_PROFILE, profile });
+
+      return saveProfile(profile);
+    }
+
+    const id = targetProfile.dataset.id;
+    const profile = { id, name, content };
+    sendMessage({ type: UPDATE_PROFILE, profile });
+
+    return saveProfile(profile);
+  };
+
+  const onDeleteProfile = (event) => {
+    const targetProfile = event.target.parentElement.parentElement;
+    const buttonsWrapper = targetProfile.children[2];
+    const id = targetProfile.dataset.id;
+
+    buttonsWrapper.children[0].removeEventListener('click', onSaveProfile);
+    buttonsWrapper.children[1].removeEventListener('click', onDeleteProfile);
+    profilesWrapper.removeChild(targetProfile);
+
+    if (id) {
+      sendMessage({ type: UPDATE_PROFILE, profile: { id } });
+
+      return deleteProfile(id);
+    }
+  };
+
+  const createProfile = ({ name = '', content = [], id }) => {
+    const profileDiv = document.createElement('div');
+    const profileName = document.createElement('input');
+    const profileContent = document.createElement('textArea');
+    const buttonsWrapper = document.createElement('div');
+    const saveButton = document.createElement('button');
+    const deleteButton = document.createElement('button');
+
+    if (id) {
+      profileDiv.dataset.id = id;
+    }
+
+    profileDiv.classList.add('profile');
+    buttonsWrapper.classList.add('buttons-wrapper');
+    saveButton.classList.add('button');
+    deleteButton.classList.add('button', 'delete-button');
+
+    profileName.placeholder = 'Profile Name';
+    profileContent.placeholder = 'mpv args (1 per line)';
+
+    saveButton.addEventListener('click', onSaveProfile);
+    deleteButton.addEventListener('click', onDeleteProfile);
+
+    profileContent.value = content.length ? content.join('\n') + '\n' : '';
+    profileName.value = name;
+
+    saveButton.textContent = 'save';
+    deleteButton.textContent = 'delete';
+
+    buttonsWrapper.append(saveButton, deleteButton);
+    profileDiv.append(profileName, profileContent, buttonsWrapper);
+
+    return profileDiv;
+  }
+
+  const load = async () => {
+    addButton.addEventListener('click', () => {
+      const emptyProfile = createProfile({});
+
+      emptyProfile.classList.add('new-profile');
+      profilesWrapper.appendChild(emptyProfile);
+    });
+
+    const profiles = await getProfiles();
+    const profileElements = profiles.map(pf => createProfile(pf));
+    profilesWrapper.replaceChildren(...profileElements);
+  };
+
+  window.addEventListener('load', load);
+})();

--- a/options/options.js
+++ b/options/options.js
@@ -92,7 +92,7 @@
     profilesWrapper.removeChild(targetProfile);
 
     if (id) {
-      sendMessage({ type: UPDATE_PROFILE, profile: { id } });
+      sendMessage({ type: DELETE_PROFILE, profile: { id } });
 
       return deleteProfile(id);
     }

--- a/package-chromium.sh
+++ b/package-chromium.sh
@@ -30,6 +30,7 @@ while read -r file; do
 done < dist.files
 
 # chromium generates dist.pem on first use
+# NOTE(2024-01): This seems to be broken for MV2 extensions.
 if [ -f dist.pem ]; then
   "${browser}" --pack-extension=dist --pack-extension-key=dist.pem
 else


### PR DESCRIPTION
Integrate MPV profiles to MV3 extension
==========

# Description
These changes allow the MPV profiles feature from the MV2 version of the extension to work with the changes for MV3

# Main changes
- Use `chrome.runtime.sendMessage` API instead of `chrome.extension.getBackgroundPage()`
- Rework context menu entries registration

# Pending tasks (TODOs)
- Platform identification. I didn't know if that should be kept or removed for mv3. I based my changes on what it was originally on the mv3 branch which means no platform identification.

# Tests
I tested the feature and it is working on Google Chrome v120.0.6099.225 for windows.
